### PR TITLE
Fixnullprops

### DIFF
--- a/Export-PendingAccounts.ps1
+++ b/Export-PendingAccounts.ps1
@@ -1,32 +1,70 @@
-﻿###########################################################
-#
-# Export-PendingAccounts.ps1
-#
-# Copyright 2019 Michael West
-#
-# This script is not officially supported or endorsed by CyberArk, Inc.
-#
-# Licensed under the MIT License
-#
-###########################################################
+﻿<#
+	.SYNOPSIS
+	Exports pending accounts from vault into CSV file
+	.PARAMETER VaultAddress
+	The DNS Name or IP Address of the vault. Required.
+	.PARAMETER PACLIPath
+	Path to the PACLI executable. Defaults to "PACLI\pacli.exe"
+	.PARAMETER CredFilePath
+	Path to credentials file created by CyberArk CreateCredFile.exe. Defaults to "user.ini"
+	.PARAMETER OutputFile
+    Name of CSV file for output. Defaults to "PendingAccounts.csv"
+    .PARAMETER AllowSelfSignedCertificates
+    Set to $true if vault uses a self signed certificate
+    .PARAMETER AuthChangePassword
+    If true, password in $credFilePath will be rotated on login. Defaults to true.
+	.NOTES
+	###########################################################
+    #   
+    # Export-PendingAccounts.ps1
+    #
+    # Copyright 2019 Michael West
+    #
+    # This script is not officially supported or endorsed by CyberArk, Inc.
+    #
+    # Licensed under the MIT License
+    #
+    ###########################################################
+    Updates by Justin B. Alcorn 2020
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword","")]
+Param(
+    [Parameter(
+        Mandatory = $true,
+        ValueFromPipelineByPropertyName = $true
+    )]
+    [string]$VaultAddress,
 
-# Change these properties for your Vault install:
-$VaultAddress = "vault.example.com"
+    [Parameter(
+        Mandatory = $false,
+        ValueFromPipelineByPropertyName = $true
+    )]
+    [string]$PACLIPath = "PACLI\Pacli.exe",
 
-# Location of cred file to use
-$CredFilePath = "user.ini"
+    [Parameter(
+        Mandatory = $false,
+        ValueFromPipelineByPropertyName = $true
+    )]
+    [string]$CredFilePath = "user.ini",
 
-# Location of PACLI executable
-$PACLIPath = "PACLI\Pacli.exe"
+    [Parameter(
+        Mandatory = $false,
+        ValueFromPipelineByPropertyName = $true
+    )]
+    [string]$OutputFile = "PendingAccounts.csv",
 
-# Location of output CSV file
-$OutputFile = "PendingAccounts.csv"
+    [Parameter(
+        Mandatory = $false,
+        ValueFromPipelineByPropertyName = $true
+    )]
+    [boolean]$AllowSelfSignedCertificates = $false,
 
-# If you use a self-signed cert on the Vault, set this to true
-$AllowSelfSignedCertificates = $false
-
-# This will cause PACLI to rotate the password of the account in the cred file automatically
-$AutoChangePassword = $true
+    [Parameter(
+        Mandatory = $false,
+        ValueFromPipelineByPropertyName = $true
+    )]
+    [boolean]$AutoChangePassword = $true
+)
 
 # Properties to show first in final report columns
 # This is so that the output looks similar to the Pending Accounts tab

--- a/Export-PendingAccounts.ps1
+++ b/Export-PendingAccounts.ps1
@@ -27,7 +27,7 @@
     ###########################################################
     Updates by Justin B. Alcorn 2020
 #>
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword","")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
 Param(
     [Parameter(
         Mandatory = $true,
@@ -72,9 +72,9 @@ $ShowFirstProperties = "UserName", "Address", "DiscoveryPlatformType", "Dependen
 
 # Properties to exclude in final report
 # We use this to remove some internal properties not useful in this case
-$ExcludeProperties =  "InternalName", "DeletionDate", "DeletionBy", "LastUsedDate", "LastUsedBy",
-    "Size", "History", "RetrieveLock", "LockDate", "LockedBy", "FileID", "Draft", "Accessed",
-    "LockedByGW", "LockedByUserId", "Safename", "Folder", "user", "vault", "sessionID", "MasterPassFolder"
+$ExcludeProperties = "InternalName", "DeletionDate", "DeletionBy", "LastUsedDate", "LastUsedBy",
+"Size", "History", "RetrieveLock", "LockDate", "LockedBy", "FileID", "Draft", "Accessed",
+"LockedByGW", "LockedByUserId", "Safename", "Folder", "user", "vault", "sessionID", "MasterPassFolder"
 
 # End settings
 
@@ -110,7 +110,7 @@ Set-PVConfiguration -ClientPath $PACLIPath
 Start-PVPacli
 New-PVVaultDefinition -vault $Vault -address $VaultAddress -preAuthSecuredSession -trustSSC:$AllowSelfSignedCertificates
 try {
-Connect-PVVault -user $User -logonFile $CredFilePath -autoChangePassword:$AutoChangePassword
+    Connect-PVVault -user $User -logonFile $CredFilePath -autoChangePassword:$AutoChangePassword
 }
 catch {
     Stop-PVPacli
@@ -145,16 +145,18 @@ foreach ($file in $files) {
 
 # Find dependencies and fill in some basic info
 foreach ($file in $files | Where { $_.MasterPassName -ne $null }) {
-    $masterpass = $files | Where { $_.Filename -eq $file.MasterPassName}
+    $masterpass = $files | Where { $_.Filename -eq $file.MasterPassName }
 
     $PropertiesToCopy = "UserName", "Dependencies", "MachineOSFamily", "OSVersion", "Domain", "OU",
     "LastPasswordSetDate", "LastLogonDate", "AccountExpirationDate", "PasswordNeverExpires", "AccountCategory"
 
     # Copy property info over if not null
     foreach ($PropertyName in $PropertiesToCopy) {
-        $property = $masterpass | select -ExpandProperty $PropertyName
-        if ($property -ne $null) {
-            $file | Add-Member -NotePropertyName $PropertyName -NotePropertyValue $property
+        if ($masterpass.PSObject.Properties.Name -contains $PropertyName) {
+            $property = $masterpass | select -ExpandProperty $PropertyName
+            if ($property -ne $null) {
+                $file | Add-Member -NotePropertyName $PropertyName -NotePropertyValue $property
+            }
         }
     }
 }


### PR DESCRIPTION
I had some masterpass accounts that didn't have DOMAIN property, and the -ExpandProperty threw an error.  Added a check to make sure properties exist.

This includes all the PoshPACLI and parameterize changes.